### PR TITLE
Trigger Terraform as deploy stage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: 'Terraform Init'
+    - name: 'Prepare Terraform'
       uses: hashicorp/terraform-github-actions@master
       with:
         tf_actions_version: 0.12.20
@@ -18,7 +18,14 @@ jobs:
         tf_actions_comment: false
         args: '-backend-config="token=${{ secrets.TF_API_TOKEN }}" -backend-config="organization=foreign-language-reader"'
 
-    - name: 'Terraform plan'
+    - name: 'Plan infrastucture changes'
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: 0.12.20
+        tf_actions_subcommand: 'plan'
+        tf_actions_comment: false
+
+    - name: 'Apply infrastucture changes'
       uses: hashicorp/terraform-github-actions@master
       with:
         tf_actions_version: 0.12.20


### PR DESCRIPTION
Sometimes, we try to deploy to infrastructure that does not exist yet. This keeps deployment from happening until after infrastructure has been created.