### PR TITLE
Job to run database migrations

### DIFF
--- a/api/lib/api/release.ex
+++ b/api/lib/api/release.ex
@@ -1,0 +1,18 @@
+defmodule Api.Release do
+  @app :api
+
+  def migrate do
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  def rollback(repo, version) do
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  defp repos do
+    Application.load(@app)
+    Application.fetch_env!(@app, :ecto_repos)
+  end
+end


### PR DESCRIPTION
Now we can migrate the API database with `bin/api eval "Api.Release.migrate"`