### PR TITLE
Drop JVM metrics

### DIFF
--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricsReporter.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricsReporter.scala
@@ -16,7 +16,7 @@ import javax.inject.{Inject, Singleton}
 class MetricsReporter @Inject() (holder: MetricHolder, config: Configuration) {
   // JVM metrics
   val getJvmMetrics: Boolean =
-    config.getOptional[Boolean]("metrics.reportJVM").getOrElse(true)
+    config.getOptional[Boolean]("metrics.reportJVM").getOrElse(false)
 
   def initialize(): Unit = {
     if (getJvmMetrics) {


### PR DESCRIPTION
They are mostly noise and we can't afford it. We need to stay under 10k metrics to remain free.