### PR TITLE
Disable branch protections

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.79-SNAPSHOT"
+version in ThisBuild := "1.5.80-SNAPSHOT"


### PR DESCRIPTION
If we have branch protections, then the version bump commits get rejected, and the build process is blocked. These should not be enabled again.