### PR TITLE
Namespace fluentlabs metrics

### DIFF
--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricHolder.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricHolder.scala
@@ -168,7 +168,7 @@ class MetricHolder {
 }
 
 object MetricHolder {
-  val namespace = "flr_"
+  val namespace = "fluentlabs_api_"
   val logger: Logger = Logger(this.getClass)
 
   // Handle duplicate registry when running locally


### PR DESCRIPTION
Namespace the fluentlabs metrics correctly so we persist it to grafana cloud.