### PR TITLE
Upgrade all Alpine 3.12 packages to the latest versions

### DIFF
--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -5,4 +5,4 @@
 FROM openjdk:18-jdk-alpine3.15
 LABEL maintainer="reader@lucaskjaerozhang.com"
 WORKDIR /app
-RUN apk add --no-cache bash=5.0.17-r0
+RUN apk add --no-cache bash

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -17,5 +17,10 @@ WORKDIR /app
 RUN apk add --no-cache bash=5.0.17-r0
 
 # Manually  upgrade all packages to avoid security vulnerabilities
-# hadolint ignore=DL3017
-RUN apk -U upgrade
+RUN apk add --upgrade apk-tools=2.10.8-r0 \
+                      busybox=1.31.1-r21 \
+                      libcrypto1.1=1.1.1l-r0 \
+                      libssl1.1=1.1.1l-r0 \
+                      ssl_client=1.31.1-r21 \
+                      p11-kit=0.23.22-r0 \
+                      p11-kit-trust=0.23.22-r0

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -14,9 +14,11 @@ FROM openjdk:15-ea-jdk-alpine3.12
 
 LABEL maintainer="reader@lucaskjaerozhang.com"
 WORKDIR /app
+
+# The play framework runners are bash scripts, so we need this to run the service.
 RUN apk add --no-cache bash=5.0.17-r0
 
-# Manually  upgrade all packages to avoid security vulnerabilities
+# Manually upgrade all packages to avoid security vulnerabilities
 RUN apk add --upgrade apk-tools=2.10.8-r0 \
                       busybox=1.31.1-r21 \
                       libcrypto1.1=1.1.1l-r0 \

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -20,7 +20,7 @@ RUN apk add --no-cache bash=5.0.17-r0
 
 # Manually upgrade all packages to avoid security vulnerabilities
 RUN apk add --upgrade apk-tools=2.10.8-r0 \
-                      busybox=1.31.1-r21 \
+                      busybox=1.34.1-r5 \
                       libcrypto1.1=1.1.1l-r0 \
                       libssl1.1=1.1.1l-r0 \
                       ssl_client=1.31.1-r21 \

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -5,4 +5,4 @@
 FROM openjdk:18-jdk-alpine3.15
 LABEL maintainer="reader@lucaskjaerozhang.com"
 WORKDIR /app
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash=5.1.8-r0

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -2,7 +2,7 @@
 # - Keep all files on same os / java version
 # - Perform basic setup
 # - Prevent re-pulling from docker hub, to avoid rate limiting.
-FROM openjdk:15-ea-jdk-alpine3.12
+FROM openjdk:18-jdk-alpine3.15
 LABEL maintainer="reader@lucaskjaerozhang.com"
 WORKDIR /app
 RUN apk add --no-cache bash=5.0.17-r0

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -16,3 +16,5 @@ LABEL maintainer="reader@lucaskjaerozhang.com"
 WORKDIR /app
 RUN apk add --no-cache bash=5.0.17-r0
 
+# Manually  upgrade all packages to avoid security vulnerabilities
+RUN apk -U upgrade

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -20,7 +20,7 @@ RUN apk add --no-cache bash=5.0.17-r0
 
 # Manually upgrade all packages to avoid security vulnerabilities
 RUN apk add --upgrade apk-tools=2.10.8-r0 \
-                      busybox=1.34.1-r5 \
+                      busybox=1.31.1-r21 \
                       libcrypto1.1=1.1.1l-r0 \
                       libssl1.1=1.1.1l-r0 \
                       ssl_client=1.31.1-r21 \

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -17,4 +17,5 @@ WORKDIR /app
 RUN apk add --no-cache bash=5.0.17-r0
 
 # Manually  upgrade all packages to avoid security vulnerabilities
+# hadolint ignore=DL3017
 RUN apk -U upgrade

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -2,7 +2,17 @@
 # - Keep all files on same os / java version
 # - Perform basic setup
 # - Prevent re-pulling from docker hub, to avoid rate limiting.
-FROM openjdk:18-jdk-alpine3.15
+
+
+FROM openjdk:15-ea-jdk-alpine3.12
+# This docker image isn't maintained anymore, the latest version that's still getting updates is 17.
+# Unfortunately, the current guice supports java <= 16, pending this issue:
+# https://github.com/google/guice/issues/1536
+
+# This is one of many reasons why I want to drop play framework.
+# But until the patch is released, I'll manually upgrade the container image.
+
 LABEL maintainer="reader@lucaskjaerozhang.com"
 WORKDIR /app
-RUN apk add --no-cache bash=5.1.8-r0
+RUN apk add --no-cache bash=5.0.17-r0
+

--- a/Dockerfile_builder
+++ b/Dockerfile_builder
@@ -20,7 +20,7 @@ RUN apk add --no-cache wget=1.21.2-r2 && \
     mkdir -p "$SBT_HOME" && \
     wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" |  tar xz -C $INSTALL_DIR && \
     echo "- with sbt $SBT_VERSION" >> /root/.built && \
-    apk delete wget
+    apk del wget
 
 # Cache dependencies
 COPY project project

--- a/Dockerfile_builder
+++ b/Dockerfile_builder
@@ -16,7 +16,7 @@ WORKDIR /app
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 # Install sbt
-RUN apk add --no-cache wget=1.21.2-r2 && \
+RUN apk add --no-cache wget=1.20.3-r1 && \
     mkdir -p "$SBT_HOME" && \
     wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" |  tar xz -C $INSTALL_DIR && \
     echo "- with sbt $SBT_VERSION" >> /root/.built && \

--- a/Dockerfile_builder
+++ b/Dockerfile_builder
@@ -20,9 +20,10 @@ RUN apk add --no-cache wget=1.20.3-r1 && \
     mkdir -p "$SBT_HOME" && \
     wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" |  tar xz -C $INSTALL_DIR && \
     echo "- with sbt $SBT_VERSION" >> /root/.built && \
-    apk del wget
+    apk del wget # wget just exists to install sbt
 
 # Cache dependencies
+# The build.sbt is a stub sbt build file that just has dependencies but no code.
 COPY project project
 COPY build-dependencies build.sbt
 COPY coursier_cache /root/.cache/coursier/v1/

--- a/Dockerfile_builder
+++ b/Dockerfile_builder
@@ -16,10 +16,11 @@ WORKDIR /app
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 # Install sbt
-RUN apk add --no-cache wget=1.20.3-r1 && \
+RUN apk add --no-cache wget=1.21.2-r2 && \
     mkdir -p "$SBT_HOME" && \
     wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" |  tar xz -C $INSTALL_DIR && \
-    echo "- with sbt $SBT_VERSION" >> /root/.built
+    echo "- with sbt $SBT_VERSION" >> /root/.built && \
+    apk delete wget
 
 # Cache dependencies
 COPY project project

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,6 +78,7 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
   val jacksonCore =
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
+  val commonsCompress = "org.apache.commons" % "commons-compress" % "1.21"
 
   // Do these still apply without spark?
   val htrace = "org.apache.htrace" % "htrace-core" % "4.0.0-incubating"
@@ -116,7 +117,8 @@ object ProjectDependencies {
     Dependencies.log4jApi,
     Dependencies.log4jCore,
     Dependencies.log4jImplementation,
-    Dependencies.log4jJson
+    Dependencies.log4jJson,
+    Dependencies.commonsCompress
   )
 
   val apiDependencies: Seq[ModuleID] =


### PR DESCRIPTION
The openjdk version we use `openjdk:15-ea-jdk-alpine3.12` is no longer maintained, with the earliest supported version being JDK 17. However, guice doesn't support Java 17, and thus we are blocked.

In the long term, the solution is to wait for Guice to fix the issue (identified in September), or find dependencies that are more up to date.

In the short term, we can mitigate these problems by just manually upgrading insecure packages. This closes 60+ vulnerabilities, so it's worth doing. This doesn't fix the already broken build, but it brings us a lot closer.