### PR TITLE
Include base changes when doing security baseline.

### DIFF
--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -63,7 +63,7 @@ jobs:
     # Remember not to push
     - name: Build dependencies image
       run: |
-        docker pull lkjaero/foreign-language-reader-api:builder
+        docker build . -f Dockerfile_base -t lkjaero/foreign-language-reader-api:base
         docker build . -f Dockerfile_builder -t lkjaero/foreign-language-reader-api:builder
 
     - name: Build container

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,14 +63,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - uses: dorny/paths-filter@v2.10.2
-        name: Check if dependencies have changed
-        id: changed_dependencies
-        with:
-          filters: |
-            dependencies:
-              - 'project/Dependencies.scala'
       
       - uses: dorny/paths-filter@v2.10.2
         name: Check which docker images to rebuild
@@ -80,6 +72,7 @@ jobs:
             base:
               - 'Dockerfile_base'
             dependencies:
+              - 'Dockerfile_base'
               - 'project/Dependencies.scala'
     
       - name: Rebuild base image


### PR DESCRIPTION
## Problem
If we fix security problems in the docker image (but not java dependencies level), it won't be reflected in the baseline. This ultimately means our security scans don't reflect the reality of what we're deploying.

## Solution
Properly account for the situation by building everything for the baseline scan.