### PR TITLE
Remediate CVE-2020-28928

### DIFF
--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -27,6 +27,7 @@ RUN apk add --no-cache bash=5.1.0-r0
 RUN apk add --upgrade busybox=1.32.1-r7 \
                       libcrypto1.1=1.1.1l-r0 \
                       libssl1.1=1.1.1l-r0 \
+                      musl-utils=1.2.2-r1 \
                       ssl_client=1.32.1-r7 \
                       p11-kit=0.23.22-r0 \
                       p11-kit-trust=0.23.22-r0


### PR DESCRIPTION
Our version of musl-tools is vulnerable, let's upgrade to a secure version.